### PR TITLE
Migrate from master/slave words

### DIFF
--- a/procs/processamento/src/pipeline/base_filter.py
+++ b/procs/processamento/src/pipeline/base_filter.py
@@ -558,7 +558,7 @@ class BaseFilter(object):
 			candidates = [m for m in rs_status['members'] if m['stateStr'] == 'SECONDARY']
 			
 			shuffle(candidates)
-			return pymongo.Connection(candidates[0]['name'], slave_okay=True)	
+			return pymongo.Connection(candidates[0]['name'], subordinate_okay=True)	
 		else:
 			return connection
 		

--- a/procs/processamento/src/pipeline/reader_filter.py
+++ b/procs/processamento/src/pipeline/reader_filter.py
@@ -138,7 +138,7 @@ class ReaderFilter(BaseFilter):
 		self.add_backpressure_callback(back_pressure)
 
 		mongodb = self.workflow['global']['mongodb']['host']
-		conn = pymongo.Connection(mongodb, slave_okay=False)
+		conn = pymongo.Connection(mongodb, subordinate_okay=False)
 		oplog = conn.local['oplog.rs']
 		br_tz = pytz.timezone('America/Sao_Paulo')
 

--- a/procs/processamento/src/pipeline/updater_filter.py
+++ b/procs/processamento/src/pipeline/updater_filter.py
@@ -23,7 +23,7 @@ class UpdaterFilter(BaseFilter):
 		self.timestamp = None
 		self.counter = 0
 		self.pid = os.getpid()
-		self.conn = pymongo.Connection(self.workflow['global']['mongodb-updater']['mongodb'], slave_okay=False)
+		self.conn = pymongo.Connection(self.workflow['global']['mongodb-updater']['mongodb'], subordinate_okay=False)
 		
 	def process(self):
 		try:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.